### PR TITLE
fix HTTPS on server

### DIFF
--- a/transports/stratum_http.py
+++ b/transports/stratum_http.py
@@ -268,7 +268,7 @@ class SSLRequestHandler(StratumJSONRPCRequestHandler):
 class SSLTCPServer(SocketServer.TCPServer):
     def __init__(self, server_address, certfile, keyfile, RequestHandlerClass, bind_and_activate=True):
         SocketServer.BaseServer.__init__(self, server_address, RequestHandlerClass)
-        ctx = SSL.Context(SSL.SSLv3_METHOD)
+        ctx = SSL.Context(SSL.SSLv23_METHOD)
         ctx.use_privatekey_file(keyfile)
         ctx.use_certificate_file(certfile)
         self.socket = SSL.Connection(ctx, socket.socket(self.address_family, self.socket_type))


### PR DESCRIPTION
I've changed transports/stratum_http.py from ctx = SSL.Context(SSL.SSLv3_METHOD) to ctx = SSL.Context(SSL.SSLv23_METHOD) . Makes HTTPS work for me on a Windows 1.5.3 client. stratum_tcp.py uses ssl.PROTOCOL_SSLv23 anyway so should be fair?
