### PR TITLE
[perf] Fetch keys of mempool history maps outside of loop.

### DIFF
--- a/backends/bitcoind/blockchain_processor.py
+++ b/backends/bitcoind/blockchain_processor.py
@@ -736,8 +736,11 @@ class BlockchainProcessor(Processor):
                 new_mempool_hist[addr] = h
 
         # invalidate cache for mempool addresses whose mempool history has changed
-        for addr in new_mempool_hist.keys():
-            if addr in self.mempool_hist.keys():
+        new_mempool_hist_keys = new_mempool_hist.keys()
+        self_mempool_hist_keys = self.mempool_hist.keys()
+        
+        for addr in new_mempool_hist_keys:
+            if addr in self_mempool_hist_keys:
                 if self.mempool_hist[addr] != new_mempool_hist[addr]:
                     self.invalidate_cache(addr)
             else:
@@ -745,8 +748,8 @@ class BlockchainProcessor(Processor):
 
         # invalidate cache for addresses that are removed from mempool ?
         # this should not be necessary if they go into a block, but they might not
-        for addr in self.mempool_hist.keys():
-            if addr not in new_mempool_hist.keys():
+        for addr in self_mempool_hist_keys:
+            if addr not in new_mempool_hist_keys:
                 self.invalidate_cache(addr)
         
 


### PR DESCRIPTION
I'm running an electrum server node on somewhat slow hardware and suffering a bit from high cpu usage,  This change cuts time spent in memory pool processing by more than half.
On my core i7 it goes from ~3.5 to ~1.5 seconds and on my slow node (atom cpu) from 60+ seconds to ~20 seconds.
