### PR TITLE
Fixed some things in the Bitcoind compile description

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -102,7 +102,9 @@ it needs to be patched with an electrum specific patch.
     $ tar xfz bitcoin-0.8.1-linux.tar.gz
     $ cd bitcoin-0.8.1-linux/src
     $ patch -p1 < ~/src/electrum/server/patch/patch
+    $ cd src
     $ make USE_UPNP= -f makefile.unix
+    $ ln -s ~/src/bitcoin-0.8.1-linux/src/src/bitcoind ~/bin/bitcoind
 
 ### Step 4. Configure and start bitcoind
 


### PR DESCRIPTION
- fixed: added 'cd src' in between patch and make, because make has to be run in src/src not in src
- fixed: added 'ln' line after the compile so that the calls to 'bitcoind' later in the HOWTO actually work
