### PR TITLE
Retry connection between Electrum and Bitcoind.

### DIFF
--- a/backends/bitcoind/blockchain_processor.py
+++ b/backends/bitcoind/blockchain_processor.py
@@ -14,6 +14,7 @@ import urllib
 from backends.bitcoind import deserialize
 from processor import Processor, print_log
 from utils import *
+from functools import wraps
 
 
 class BlockchainProcessor(Processor):
@@ -108,13 +109,58 @@ class BlockchainProcessor(Processor):
 
         threading.Timer(10, self.main_iteration).start()
 
+    def retry(ExceptionToCheck, tries=4, delay=3, backoff=2, logger=None):
+        """Retry calling the decorated function using an exponential backoff.
+
+        http://www.saltycrane.com/blog/2009/11/trying-out-retry-decorator-python/
+        original from: http://wiki.python.org/moin/PythonDecoratorLibrary#Retry
+
+        :param ExceptionToCheck: the exception to check. may be a tuple of
+            exceptions to check
+        :type ExceptionToCheck: Exception or tuple
+        :param tries: number of times to try (not retry) before giving up
+        :type tries: int
+        :param delay: initial delay between retries in seconds
+        :type delay: int
+        :param backoff: backoff multiplier e.g. value of 2 will double the delay
+            each retry
+        :type backoff: int
+        :param logger: logger to use. If None, print
+        :type logger: logging.Logger instance
+        """
+        def deco_retry(f):
+
+            print "Retry..."
+            @wraps(f)
+            def f_retry(*args, **kwargs):
+                mtries, mdelay = tries, delay
+                while mtries > 1:
+                    try:
+                        return f(*args, **kwargs)
+                    except ExceptionToCheck, e:
+                        msg = "%s, Retrying in %d seconds..." % (str(e), mdelay)
+                        if logger:
+                            logger.warning(msg)
+                        else:
+                            print msg
+                        time.sleep(mdelay)
+                        mtries -= 1
+                        mdelay *= backoff
+                return f(*args, **kwargs)
+
+            return f_retry  # true decorator
+
+        return deco_retry
+
+
+    @retry(IOError, tries=4, delay=30, backoff=1, logger=None)
     def bitcoind(self, method, params=[]):
         postdata = dumps({"method": method, 'params': params, 'id': 'jsonrpc'})
-        try:
-            respdata = urllib.urlopen(self.bitcoind_url, postdata).read()
-        except:
-            traceback.print_exc(file=sys.stdout)
-            self.shared.stop()
+#        try:
+        respdata = urllib.urlopen(self.bitcoind_url, postdata).read()
+#        except:
+#            traceback.print_exc(file=sys.stdout)
+#            self.shared.stop()
 
         r = loads(respdata)
         if r['error'] is not None:


### PR DESCRIPTION
Included code from http://www.saltycrane.com/blog/2009/11/trying-out-retry-decorator-python/
to wrap a retry loop around the connection to bitcoind.

When bitcoind fails (ie: When it is restarted weekly.) electrum-server
will now attempt to connect 4 times at 30 second intervals before
aborting.

I know very little Python, and am not at all familiar with the
Electrum codebase, so this patch may well need some polish.  But it
works just fine for me.
