### PR TITLE
Changes the path of log file. Urges admin to run electrum server as non ...

### DIFF
--- a/start
+++ b/start
@@ -38,7 +38,7 @@ if [ ! -d $path ]; then
     fi
 fi
 
-log_dir=/home/$USER/log
+log_dir=~/log
 
 if [ ! -d $log_dir ]; then
     echo "Created logging directory in $USER's home."


### PR DESCRIPTION
...root.

Till now start script was uging /var/log/electrum.log as the log file path.
That's problematic, when electrum server is launched by an unprivileged user
and without sudo. As a matter of fact there is no need to run electrum server
as root, and suggested way in electrum server's HOWTO is creating a new user.

Instead of messing with /var/log permissions or running start script with
sudo, this commit changes logging directory to user's home.

Also it urges the user to run script as non root user.

This commit came up as a need, in my debian server where I have setup user "bitcoin" to run bitcoind and electrum server.
