### PR TITLE
Fixed display of <password> in HOWTO.md

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -25,7 +25,7 @@ bitcoin user has sudo rights, so we use '$ sudo command' when we need to.
 
 Strings that are surrounded by "lower than" and "greater than" ( < and > )
 should be replaced by the user with something appropriate. For example,
-<password> should be replaced by a user chosen password. Do not confuse this
+\<password\> should be replaced by a user chosen password. Do not confuse this
 notation with shell redirection ('command < file' or 'command > file')!
 
 Lines that lack hash or dollar signs are pastes from config files. They


### PR DESCRIPTION
needed to escape the < and >
