### PR TITLE
Fix 'electrum-server start' for regular users

### DIFF
--- a/electrum-server
+++ b/electrum-server
@@ -61,7 +61,7 @@ case "$1" in
 	if [ `id -u` = 0 ] ; then
             su $user -c "$cmd"
 	else
-	    $cmd
+	    eval $cmd
 	fi
 	;;
     stop)


### PR DESCRIPTION
The line `"ulimit -n 65536 ; nohup run_electrum_server > /dev/null &"` is currently executed as a single command (because the quotes protect the semicolon), and the server is not started. By using `eval`, it should be correctly interpreted as two commands.
