### PR TITLE
Update HOWTO.md because of 'irc' version

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -50,7 +50,7 @@ issue so you can continue following this howto.
 **Software.** A recent Linux 64-bit distribution with the following software
 installed: `python`, `easy_install`, `git`, standard C/C++
 build chain. You will need root access in order to install other software or
-Python libraries. 
+Python libraries. Python 2.7 is the minimum supported version.
 
 **Hardware.** The lightest setup is a pruning server with diskspace 
 requirements of about 10 GB for the electrum database. However note that 


### PR DESCRIPTION
Check my comment on commit 0454db3f85584e3d00de6d14fba9cdbdf55e6207. Because of the minimum version of irc change, Python 2.6 is no longer supported.