### PR TITLE
Cleanify log output.

### DIFF
--- a/src/ircthread.py
+++ b/src/ircthread.py
@@ -93,7 +93,7 @@ class IrcThread(threading.Thread):
         try:
             ip = socket.gethostbyname(line[1])
         except:
-            logger.error("gethostbyname error" + line[1])
+            logger.error("gethostbyname error " + line[1])
             return
         nick = event.arguments[4]
         host = line[1]


### PR DESCRIPTION
This changes
[28/03/2015-18:57:37] gethostbyname errorblockchain.fh-biergarten.de
[28/03/2015-18:57:40] gethostbyname errorelectrum.ml
to
[28/03/2015-18:57:37] gethostbyname error blockchain.fh-biergarten.de
[28/03/2015-18:57:40] gethostbyname error electrum.ml
in the logs. I'm bothered by this :)