### PR TITLE
fix issue #105 Thread Exception When building database

### DIFF
--- a/src/blockchain_processor.py
+++ b/src/blockchain_processor.py
@@ -113,17 +113,18 @@ class BlockchainProcessor(Processor):
         while True:
             try:
                 respdata = urllib.urlopen(self.bitcoind_url, postdata).read()
-            except:
-                print_log("cannot reach bitcoind...")
+            except BaseException as e:
+                print_log("cannot reach bitcoind...", str(e))
                 self.wait_on_bitcoind()
             else:
                 r = loads(respdata)
                 if r['error'] is not None:
                     if r['error'].get('code') == -28:
                         print_log("bitcoind still warming up...")
-                        self.wait_on_bitcoind()
-                        continue
-                    raise BaseException(r['error'])
+                    else:
+                        print_log("bitcoind error...", r['error'])
+                    self.wait_on_bitcoind()
+                    continue
                 break
         return r.get('result')
 


### PR DESCRIPTION
Go into wait_on_bitcoind instead of raising an exception when an unexpected bitcoind error number is returned. 
This allows the server to wait for bitcoind rather than just bailing out with an exception.