### PR TITLE
Remove un-needed list updating.

### DIFF
--- a/src/blockchain_processor.py
+++ b/src/blockchain_processor.py
@@ -715,7 +715,6 @@ class BlockchainProcessor(Processor):
                 continue
 
             new_tx[tx_hash] = tx
-            self.mempool_hashes.add(tx_hash)
 
         # remove older entries from mempool_hashes
         self.mempool_hashes = mempool_hashes


### PR DESCRIPTION
self.mempool_hashes is thrown away right after, so there's no need to update it in this loop