### PR TITLE
Change to make address history sorted and deterministic

### DIFF
--- a/src/storage.py
+++ b/src/storage.py
@@ -141,11 +141,14 @@ class Storage(object):
             out.append((txi, hi))
             out.append((txo, ho))
 
-        # sort
-        out.sort(key=lambda x:x[1])
-
+        
         # uniqueness
         out = set(out)
+        # sort
+        out = list(out)
+
+        out.sort(key=lambda x:x[1])
+
 
         return map(lambda x: {'tx_hash':x[0], 'height':x[1]}, out)
 


### PR DESCRIPTION
This is running on ele-rsync.1209k.com.  I've also made a similar change to jelectrum for consistent behavior.
