### PR TITLE
Make IPv4 optional for peers

### DIFF
--- a/src/ircthread.py
+++ b/src/ircthread.py
@@ -93,8 +93,8 @@ class IrcThread(threading.Thread):
         try:
             ip = socket.gethostbyname(line[1])
         except:
-            logger.error("gethostbyname error " + line[1])
-            return
+            # no IPv4 address could be resolved. Could be .onion or IPv6.
+            ip = line[1]
         nick = event.arguments[4]
         host = line[1]
         ports = line[2:]


### PR DESCRIPTION
This change removes the necessarity for peers (e.g. other servers) to have an IPv4 address that the local DNS can resolve.

That's useful for Tor hidden services whose .onion addresses can't be resolved through the usual DNS system. We'll just leave it to the clients to resolve IP addresses.