### PR TITLE
Allow users to specify a hidden service name as an alternative to the hostname

### DIFF
--- a/electrum.conf.sample
+++ b/electrum.conf.sample
@@ -3,6 +3,8 @@
 username = 
 # hostname. set it to a FQDN in order to be reached from outside
 host = localhost
+# Add your .onion address here if your server has one.
+#hidden_service = 
 # ports
 electrum_rpc_port = 8000
 stratum_tcp_port = 50001

--- a/run_electrum_server.py
+++ b/run_electrum_server.py
@@ -101,6 +101,7 @@ def create_config(filename=None):
     config.set('server', 'logfile', '/var/log/electrum.log')
     config.set('server', 'donation_address', '')
     config.set('server', 'max_subscriptions', '10000')
+    config.set('server', 'hidden_service', '')
 
     config.add_section('leveldb')
     config.set('leveldb', 'path', '/dev/shm/electrum_db')

--- a/src/ircthread.py
+++ b/src/ircthread.py
@@ -42,6 +42,7 @@ class IrcThread(threading.Thread):
         self.pruning_limit = config.get('leveldb', 'pruning_limit')
         self.nick = 'E_' + self.nick
         self.password = None
+        self.hidden_service = config.get('server', 'hidden_service')
 
     def getname(self):
         s = 'v' + VERSION + ' '
@@ -118,6 +119,9 @@ class IrcThread(threading.Thread):
             client = irc.client.Reactor()
             try:
                 c = client.server().connect('irc.freenode.net', 6667, self.nick, self.password, ircname=self.ircname)
+                if self.hidden_service.endswith(".onion"):
+                    ircname = self.hidden_service + ' ' + self.getname()
+                    client.server().connect('irc.freenode.net', 6667, self.nick + "_tor", self.password, ircname=ircname)
             except irc.client.ServerConnectionError:
                 logger.error('irc', exc_info=True)
                 time.sleep(10)


### PR DESCRIPTION
This makes the server spawn two irc clients that join #electrum, both with different hosts reported:

    [Who] #electrum ~E_bauerj 192.198.88.125 kornbluth.freenode.net E_bauerj H 0 electrum.bauerj.eu v1.0 p10000 t s
    [Who] #electrum ~E_bauerj_ 192.198.88.125 asimov.freenode.net E_bauerj_tor H 0 bauerjomfxkfgotm.onion v1.0 p10000 t s

Only the default client will be used for peer discovery as they will most likely both see the same users.

This adds a bit of join/leave spam to the irc so a better option would be to use one client to report multiple hostnames, but that's not possible with the current parser, which means all servers would need to be updated first.

To use this feature, one would need to edit the `server` section in `electrum.conf`. If that's not done, the behaviour should be the same as without this commit.