### PR TITLE
Set electrum server visible in IRC.

### DIFF
--- a/src/ircthread.py
+++ b/src/ircthread.py
@@ -68,6 +68,7 @@ class IrcThread(threading.Thread):
  
     def on_connect(self, connection, event):
         connection.join("#electrum")
+        connection.mode(self.nick, "-i")
 
     def on_join(self, connection, event):
         m = re.match("(E_.*)!", event.source)


### PR DESCRIPTION
This removes the default invisible flag in IRC.

If servers are visible, it is possible to issue a command like <del>`:WHO #electrum E_*`</del> `:WHO #electrum` and get the peer list without even joining the channel.

Someone in IRC is writing "a pure Go electrum client" and wants to use IRC for bootstrapping. It would be a bit unpleasant to have these clients join and part `#electrum` all the time so I thought it would be better if the servers would not hide from the outside.