### PR TITLE
More optimizations to block processing

### DIFF
--- a/src/blockchain_processor.py
+++ b/src/blockchain_processor.py
@@ -12,7 +12,7 @@ import deserialize
 from processor import Processor, print_log
 from storage import Storage
 from utils import logger, hash_decode, hash_encode, Hash, header_from_string, header_to_string, ProfiledThread, \
-    rev_hex, int_to_unsigned_long_bytes_hex
+    rev_hex, int_to_hex4
 
 class BlockchainProcessor(Processor):
 
@@ -528,7 +528,7 @@ class BlockchainProcessor(Processor):
         elif method == 'blockchain.utxo.get_address':
             txid = str(params[0])
             pos = int(params[1])
-            txi = (txid + int_to_unsigned_long_bytes_hex(pos)).decode('hex')
+            txi = (txid + int_to_hex4(pos)).decode('hex')
             result = self.storage.get_address(txi)
 
         elif method == 'blockchain.block.get_header':
@@ -738,7 +738,7 @@ class BlockchainProcessor(Processor):
                 if mpv:
                     addr, value = mpv[ x.get('prevout_n')]
                 else:
-                    txi = (x.get('prevout_hash') + int_to_unsigned_long_bytes_hex(x.get('prevout_n'))).decode('hex')
+                    txi = (x.get('prevout_hash') + int_to_hex4(x.get('prevout_n'))).decode('hex')
                     try:
                         addr = self.storage.get_address(txi)
                         value = self.storage.get_utxo_value(addr,txi)

--- a/src/blockchain_processor.py
+++ b/src/blockchain_processor.py
@@ -232,8 +232,8 @@ class BlockchainProcessor(Processor):
 
         with self.cache_lock:
             chunk_index = header.get('block_height')/2016
-            if self.chunk_cache.get(chunk_index):
-                self.chunk_cache.pop(chunk_index)
+            if chunk_index in self.chunk_cache:
+                del self.chunk_cache[chunk_index]
 
     def pop_header(self):
         # we need to do this only if we have not flushed
@@ -481,7 +481,7 @@ class BlockchainProcessor(Processor):
                     print_log("error rc!!")
                     self.shared.stop()
                 if l == []:
-                    self.watched_addresses.pop(addr)
+                    del self.watched_addresses[addr]
 
 
     def process(self, request, cache_only=False):
@@ -757,8 +757,7 @@ class BlockchainProcessor(Processor):
         # remove deprecated entries from mempool_addresses
         for tx_hash, addresses in self.mempool_addresses.items():
             if tx_hash not in self.mempool_hashes:
-                self.mempool_addresses.pop(tx_hash)
-                self.mempool_values.pop(tx_hash)
+                del self.mempool_addresses[tx_hash], self.mempool_values[tx_hash]
                 touched_addresses.update(addresses)
 
         # remove deprecated entries from mempool_hist
@@ -796,7 +795,7 @@ class BlockchainProcessor(Processor):
         with self.cache_lock:
             if address in self.history_cache:
                 # print_log("cache: invalidating", address)
-                self.history_cache.pop(address)
+                del self.history_cache[address]
 
         with self.watch_lock:
             sessions = self.watched_addresses.get(address)

--- a/src/blockchain_processor.py
+++ b/src/blockchain_processor.py
@@ -11,7 +11,8 @@ import urllib
 import deserialize
 from processor import Processor, print_log
 from storage import Storage
-from utils import logger, hash_decode, hash_encode, Hash, header_from_string, header_to_string, ProfiledThread, rev_hex, int_to_hex
+from utils import logger, hash_decode, hash_encode, Hash, header_from_string, header_to_string, ProfiledThread, \
+    rev_hex, int_to_unsigned_long_bytes_hex
 
 class BlockchainProcessor(Processor):
 
@@ -527,7 +528,7 @@ class BlockchainProcessor(Processor):
         elif method == 'blockchain.utxo.get_address':
             txid = str(params[0])
             pos = int(params[1])
-            txi = (txid + int_to_hex(pos, 4)).decode('hex')
+            txi = (txid + int_to_unsigned_long_bytes_hex(pos)).decode('hex')
             result = self.storage.get_address(txi)
 
         elif method == 'blockchain.block.get_header':
@@ -737,7 +738,7 @@ class BlockchainProcessor(Processor):
                 if mpv:
                     addr, value = mpv[ x.get('prevout_n')]
                 else:
-                    txi = (x.get('prevout_hash') + int_to_hex(x.get('prevout_n'), 4)).decode('hex')
+                    txi = (x.get('prevout_hash') + int_to_unsigned_long_bytes_hex(x.get('prevout_n'))).decode('hex')
                     try:
                         addr = self.storage.get_address(txi)
                         value = self.storage.get_utxo_value(addr,txi)

--- a/src/processor.py
+++ b/src/processor.py
@@ -186,7 +186,7 @@ class RequestDispatcher(threading.Thread):
     def remove_session(self, session):
         key = session.key()
         with self.lock:
-            self.sessions.pop(key)
+            del self.sessions[key]
 
     def collect_garbage(self):
         # only for HTTP sessions.

--- a/src/server_processor.py
+++ b/src/server_processor.py
@@ -45,8 +45,8 @@ class ServerProcessor(Processor):
                 self.peers[nick] = (ip, host, ports)
             if event == 'quit':
                 nick = params[0]
-                if self.peers.get(nick):
-                    self.peers.pop(nick)
+                if nick in self.peers:
+                    del self.peers[nick]
 
 
     def get_peers(self):

--- a/src/storage.py
+++ b/src/storage.py
@@ -486,7 +486,7 @@ class Storage(object):
         self.db_utxo.delete(leaf)
 
         if leaf in self.hash_list:
-            self.hash_list.pop(leaf)
+            del self.hash_list[leaf]
 
         parent = path[-1]
         letter = leaf[len(parent)]
@@ -498,7 +498,7 @@ class Storage(object):
             #print "deleting parent", parent.encode('hex')
             self.db_utxo.delete(parent)
             if parent in self.hash_list:
-                self.hash_list.pop(parent)
+                del self.hash_list[parent]
 
             l = parent_node.get_singleton()
             _hash, value = parent_node.get(l)

--- a/src/storage.py
+++ b/src/storage.py
@@ -6,7 +6,9 @@ import sys
 import threading
 
 from processor import print_log, logger
-from utils import bc_address_to_hash_160, hash_160_to_pubkey_address, hex_to_int, int_to_hex, Hash
+from utils import bc_address_to_hash_160, hash_160_to_pubkey_address, Hash, \
+    unsigned_long_long_from_bytes, unsigned_long_from_bytes, int_to_unsigned_long_long_bytes, \
+    int_to_unsigned_long_long_bytes_hex, int_to_unsigned_long_bytes, int_to_unsigned_long_bytes_hex
 
 
 """
@@ -61,13 +63,13 @@ class Node(object):
         x = self.indexof(c)
         ss = self.s[x:x+40]
         _hash = ss[0:32]
-        value = hex_to_int(ss[32:40])
+        value = unsigned_long_long_from_bytes(ss[32:40])
         return _hash, value
 
     def set(self, c, h, value):
         if h is None:
             h = chr(0)*32
-        vv = int_to_hex(value, 8).decode('hex')
+        vv = int_to_unsigned_long_long_bytes(value)
         item = h + vv
         assert len(item) == 40
         if self.has(c):
@@ -93,7 +95,7 @@ class Node(object):
             if (self.k&(1<<i)) != 0:
                 ss = self.s[x:x+40]
                 hh += ss[0:32]
-                v += hex_to_int(ss[32:40])
+                v += unsigned_long_long_from_bytes(ss[32:40])
                 x += 40
         try:
             _hash = Hash(skip_string + hh)
@@ -112,7 +114,7 @@ class Node(object):
                 k += 1<<i
                 h, value = d[chr(i)]
                 if h is None: h = chr(0)*32
-                vv = int_to_hex(value, 8).decode('hex')
+                vv = int_to_unsigned_long_long_bytes(value)
                 item = h + vv
                 assert len(item) == 40
                 s += item
@@ -262,9 +264,9 @@ class Storage(object):
                     break
                 if len(k) == KEYLENGTH:
                     txid = k[20:52].encode('hex')
-                    txpos = hex_to_int(k[52:56])
-                    h = hex_to_int(v[8:12])
-                    v = hex_to_int(v[0:8])
+                    txpos = unsigned_long_from_bytes(k[52:56])
+                    h = unsigned_long_from_bytes(v[8:12])
+                    v = unsigned_long_long_from_bytes(v[0:8])
                     out.append({'tx_hash': txid, 'tx_pos':txpos, 'height': h, 'value':v})
                 if len(out) == 1000:
                     print_log('max utxo reached', addr)
@@ -284,9 +286,9 @@ class Storage(object):
             item = h[0:80]
             h = h[80:]
             txi = item[0:32].encode('hex')
-            hi = hex_to_int(item[36:40])
+            hi = unsigned_long_from_bytes(item[36:40])
             txo = item[40:72].encode('hex')
-            ho = hex_to_int(item[76:80])
+            ho = unsigned_long_from_bytes(item[76:80])
             out.append((hi, txi))
             out.append((ho, txo))
         # uniqueness
@@ -380,7 +382,7 @@ class Storage(object):
             self.put_node(parent, parent_node)
 
         # write the new leaf
-        s = (int_to_hex(value, 8) + int_to_hex(height,4)).decode('hex')
+        s = (int_to_unsigned_long_long_bytes_hex(value) + int_to_unsigned_long_bytes_hex(height)).decode('hex')
         self.db_utxo.put(target, s)
         # the hash of a leaf is the txid
         _hash = target[20:52]
@@ -517,7 +519,7 @@ class Storage(object):
             # note: k is not necessarily a leaf
             if len(otherleaf) == KEYLENGTH:
                 ss = self.db_utxo.get(otherleaf)
-                _hash, value = otherleaf[20:52], hex_to_int(ss[0:8])
+                _hash, value = otherleaf[20:52], unsigned_long_long_from_bytes(ss[0:8])
             else:
                 _hash, value = None, None
             self.update_node_hash(otherleaf, path[:-1], _hash, value)
@@ -548,7 +550,7 @@ class Storage(object):
 
     def add_to_history(self, addr, tx_hash, tx_pos, value, tx_height):
         key = self.address_to_key(addr)
-        txo = (tx_hash + int_to_hex(tx_pos, 4)).decode('hex')
+        txo = (tx_hash + int_to_unsigned_long_bytes_hex(tx_pos)).decode('hex')
         # write the new history
         self.add_key(key + txo, value, tx_height)
         # backlink
@@ -557,7 +559,7 @@ class Storage(object):
 
     def revert_add_to_history(self, addr, tx_hash, tx_pos, value, tx_height):
         key = self.address_to_key(addr)
-        txo = (tx_hash + int_to_hex(tx_pos, 4)).decode('hex')
+        txo = (tx_hash + int_to_unsigned_long_bytes_hex(tx_pos)).decode('hex')
         # delete
         self.delete_key(key + txo)
         # backlink
@@ -568,7 +570,7 @@ class Storage(object):
         key = self.address_to_key(addr)
         leaf = key + txi
         s = self.db_utxo.get(leaf)
-        value = hex_to_int(s[0:8])
+        value = unsigned_long_long_from_bytes(s[0:8])
         return value
 
 
@@ -576,16 +578,16 @@ class Storage(object):
         key = self.address_to_key(addr)
         leaf = key + txi
         s = self.delete_key(leaf)
-        value = hex_to_int(s[0:8])
-        in_height = hex_to_int(s[8:12])
+        value = unsigned_long_long_from_bytes(s[0:8])
+        in_height = unsigned_long_from_bytes(s[8:12])
         undo[leaf] = value, in_height
         # delete backlink txi-> addr
         self.db_addr.delete(txi)
         # add to history
         s = self.db_hist.get(addr)
         if s is None: s = ''
-        txo = (txid + int_to_hex(index,4) + int_to_hex(height,4)).decode('hex')
-        s += txi + int_to_hex(in_height,4).decode('hex') + txo
+        txo = (txid + int_to_unsigned_long_bytes_hex(index) + int_to_unsigned_long_bytes_hex(height)).decode('hex')
+        s += txi + int_to_unsigned_long_bytes(in_height) + txo
         s = s[ -80*self.pruning_limit:]
         self.db_hist.put(addr, s)
 
@@ -619,7 +621,7 @@ class Storage(object):
 
         prev_addr = []
         for i, x in enumerate(tx.get('inputs')):
-            txi = (x.get('prevout_hash') + int_to_hex(x.get('prevout_n'), 4)).decode('hex')
+            txi = (x.get('prevout_hash') + int_to_unsigned_long_bytes_hex(x.get('prevout_n'))).decode('hex')
             addr = self.get_address(txi)
             if addr is not None:
                 self.set_spent(addr, txi, txid, i, block_height, undo)
@@ -650,7 +652,7 @@ class Storage(object):
         for i, x in reversed(list(enumerate(tx.get('inputs')))):
             addr = prev_addr[i]
             if addr is not None:
-                txi = (x.get('prevout_hash') + int_to_hex(x.get('prevout_n'), 4)).decode('hex')
+                txi = (x.get('prevout_hash') + int_to_unsigned_long_bytes_hex(x.get('prevout_n'))).decode('hex')
                 self.revert_set_spent(addr, txi, undo)
                 touched_addr.add(addr)
 

--- a/src/storage.py
+++ b/src/storage.py
@@ -7,7 +7,7 @@ import threading
 
 from processor import print_log, logger
 from utils import bc_address_to_hash_160, hash_160_to_pubkey_address, Hash, \
-    int_from_bytes8, int_from_bytes4, int_to_bytes8, \
+    bytes8_to_int, bytes4_to_int, int_to_bytes8, \
     int_to_hex8, int_to_bytes4, int_to_hex4
 
 
@@ -63,7 +63,7 @@ class Node(object):
         x = self.indexof(c)
         ss = self.s[x:x+40]
         _hash = ss[0:32]
-        value = int_from_bytes8(ss[32:40])
+        value = bytes8_to_int(ss[32:40])
         return _hash, value
 
     def set(self, c, h, value):
@@ -95,7 +95,7 @@ class Node(object):
             if (self.k&(1<<i)) != 0:
                 ss = self.s[x:x+40]
                 hh += ss[0:32]
-                v += int_from_bytes8(ss[32:40])
+                v += bytes8_to_int(ss[32:40])
                 x += 40
         try:
             _hash = Hash(skip_string + hh)
@@ -264,9 +264,9 @@ class Storage(object):
                     break
                 if len(k) == KEYLENGTH:
                     txid = k[20:52].encode('hex')
-                    txpos = int_from_bytes4(k[52:56])
-                    h = int_from_bytes4(v[8:12])
-                    v = int_from_bytes8(v[0:8])
+                    txpos = bytes4_to_int(k[52:56])
+                    h = bytes4_to_int(v[8:12])
+                    v = bytes8_to_int(v[0:8])
                     out.append({'tx_hash': txid, 'tx_pos':txpos, 'height': h, 'value':v})
                 if len(out) == 1000:
                     print_log('max utxo reached', addr)
@@ -286,9 +286,9 @@ class Storage(object):
             item = h[0:80]
             h = h[80:]
             txi = item[0:32].encode('hex')
-            hi = int_from_bytes4(item[36:40])
+            hi = bytes4_to_int(item[36:40])
             txo = item[40:72].encode('hex')
-            ho = int_from_bytes4(item[76:80])
+            ho = bytes4_to_int(item[76:80])
             out.append((hi, txi))
             out.append((ho, txo))
         # uniqueness
@@ -519,7 +519,7 @@ class Storage(object):
             # note: k is not necessarily a leaf
             if len(otherleaf) == KEYLENGTH:
                 ss = self.db_utxo.get(otherleaf)
-                _hash, value = otherleaf[20:52], int_from_bytes8(ss[0:8])
+                _hash, value = otherleaf[20:52], bytes8_to_int(ss[0:8])
             else:
                 _hash, value = None, None
             self.update_node_hash(otherleaf, path[:-1], _hash, value)
@@ -570,7 +570,7 @@ class Storage(object):
         key = self.address_to_key(addr)
         leaf = key + txi
         s = self.db_utxo.get(leaf)
-        value = int_from_bytes8(s[0:8])
+        value = bytes8_to_int(s[0:8])
         return value
 
 
@@ -578,8 +578,8 @@ class Storage(object):
         key = self.address_to_key(addr)
         leaf = key + txi
         s = self.delete_key(leaf)
-        value = int_from_bytes8(s[0:8])
-        in_height = int_from_bytes4(s[8:12])
+        value = bytes8_to_int(s[0:8])
+        in_height = bytes4_to_int(s[8:12])
         undo[leaf] = value, in_height
         # delete backlink txi-> addr
         self.db_addr.delete(txi)

--- a/src/storage.py
+++ b/src/storage.py
@@ -7,8 +7,8 @@ import threading
 
 from processor import print_log, logger
 from utils import bc_address_to_hash_160, hash_160_to_pubkey_address, Hash, \
-    unsigned_long_long_from_bytes, unsigned_long_from_bytes, int_to_unsigned_long_long_bytes, \
-    int_to_unsigned_long_long_bytes_hex, int_to_unsigned_long_bytes, int_to_unsigned_long_bytes_hex
+    int_from_bytes8, int_from_bytes4, int_to_bytes8, \
+    int_to_hex8, int_to_bytes4, int_to_hex4
 
 
 """
@@ -63,13 +63,13 @@ class Node(object):
         x = self.indexof(c)
         ss = self.s[x:x+40]
         _hash = ss[0:32]
-        value = unsigned_long_long_from_bytes(ss[32:40])
+        value = int_from_bytes8(ss[32:40])
         return _hash, value
 
     def set(self, c, h, value):
         if h is None:
             h = chr(0)*32
-        vv = int_to_unsigned_long_long_bytes(value)
+        vv = int_to_bytes8(value)
         item = h + vv
         assert len(item) == 40
         if self.has(c):
@@ -95,7 +95,7 @@ class Node(object):
             if (self.k&(1<<i)) != 0:
                 ss = self.s[x:x+40]
                 hh += ss[0:32]
-                v += unsigned_long_long_from_bytes(ss[32:40])
+                v += int_from_bytes8(ss[32:40])
                 x += 40
         try:
             _hash = Hash(skip_string + hh)
@@ -114,7 +114,7 @@ class Node(object):
                 k += 1<<i
                 h, value = d[chr(i)]
                 if h is None: h = chr(0)*32
-                vv = int_to_unsigned_long_long_bytes(value)
+                vv = int_to_bytes8(value)
                 item = h + vv
                 assert len(item) == 40
                 s += item
@@ -264,9 +264,9 @@ class Storage(object):
                     break
                 if len(k) == KEYLENGTH:
                     txid = k[20:52].encode('hex')
-                    txpos = unsigned_long_from_bytes(k[52:56])
-                    h = unsigned_long_from_bytes(v[8:12])
-                    v = unsigned_long_long_from_bytes(v[0:8])
+                    txpos = int_from_bytes4(k[52:56])
+                    h = int_from_bytes4(v[8:12])
+                    v = int_from_bytes8(v[0:8])
                     out.append({'tx_hash': txid, 'tx_pos':txpos, 'height': h, 'value':v})
                 if len(out) == 1000:
                     print_log('max utxo reached', addr)
@@ -286,9 +286,9 @@ class Storage(object):
             item = h[0:80]
             h = h[80:]
             txi = item[0:32].encode('hex')
-            hi = unsigned_long_from_bytes(item[36:40])
+            hi = int_from_bytes4(item[36:40])
             txo = item[40:72].encode('hex')
-            ho = unsigned_long_from_bytes(item[76:80])
+            ho = int_from_bytes4(item[76:80])
             out.append((hi, txi))
             out.append((ho, txo))
         # uniqueness
@@ -382,7 +382,7 @@ class Storage(object):
             self.put_node(parent, parent_node)
 
         # write the new leaf
-        s = (int_to_unsigned_long_long_bytes_hex(value) + int_to_unsigned_long_bytes_hex(height)).decode('hex')
+        s = (int_to_hex8(value) + int_to_hex4(height)).decode('hex')
         self.db_utxo.put(target, s)
         # the hash of a leaf is the txid
         _hash = target[20:52]
@@ -519,7 +519,7 @@ class Storage(object):
             # note: k is not necessarily a leaf
             if len(otherleaf) == KEYLENGTH:
                 ss = self.db_utxo.get(otherleaf)
-                _hash, value = otherleaf[20:52], unsigned_long_long_from_bytes(ss[0:8])
+                _hash, value = otherleaf[20:52], int_from_bytes8(ss[0:8])
             else:
                 _hash, value = None, None
             self.update_node_hash(otherleaf, path[:-1], _hash, value)
@@ -550,7 +550,7 @@ class Storage(object):
 
     def add_to_history(self, addr, tx_hash, tx_pos, value, tx_height):
         key = self.address_to_key(addr)
-        txo = (tx_hash + int_to_unsigned_long_bytes_hex(tx_pos)).decode('hex')
+        txo = (tx_hash + int_to_hex4(tx_pos)).decode('hex')
         # write the new history
         self.add_key(key + txo, value, tx_height)
         # backlink
@@ -559,7 +559,7 @@ class Storage(object):
 
     def revert_add_to_history(self, addr, tx_hash, tx_pos, value, tx_height):
         key = self.address_to_key(addr)
-        txo = (tx_hash + int_to_unsigned_long_bytes_hex(tx_pos)).decode('hex')
+        txo = (tx_hash + int_to_hex4(tx_pos)).decode('hex')
         # delete
         self.delete_key(key + txo)
         # backlink
@@ -570,7 +570,7 @@ class Storage(object):
         key = self.address_to_key(addr)
         leaf = key + txi
         s = self.db_utxo.get(leaf)
-        value = unsigned_long_long_from_bytes(s[0:8])
+        value = int_from_bytes8(s[0:8])
         return value
 
 
@@ -578,16 +578,16 @@ class Storage(object):
         key = self.address_to_key(addr)
         leaf = key + txi
         s = self.delete_key(leaf)
-        value = unsigned_long_long_from_bytes(s[0:8])
-        in_height = unsigned_long_from_bytes(s[8:12])
+        value = int_from_bytes8(s[0:8])
+        in_height = int_from_bytes4(s[8:12])
         undo[leaf] = value, in_height
         # delete backlink txi-> addr
         self.db_addr.delete(txi)
         # add to history
         s = self.db_hist.get(addr)
         if s is None: s = ''
-        txo = (txid + int_to_unsigned_long_bytes_hex(index) + int_to_unsigned_long_bytes_hex(height)).decode('hex')
-        s += txi + int_to_unsigned_long_bytes(in_height) + txo
+        txo = (txid + int_to_hex4(index) + int_to_hex4(height)).decode('hex')
+        s += txi + int_to_bytes4(in_height) + txo
         s = s[ -80*self.pruning_limit:]
         self.db_hist.put(addr, s)
 
@@ -621,7 +621,7 @@ class Storage(object):
 
         prev_addr = []
         for i, x in enumerate(tx.get('inputs')):
-            txi = (x.get('prevout_hash') + int_to_unsigned_long_bytes_hex(x.get('prevout_n'))).decode('hex')
+            txi = (x.get('prevout_hash') + int_to_hex4(x.get('prevout_n'))).decode('hex')
             addr = self.get_address(txi)
             if addr is not None:
                 self.set_spent(addr, txi, txid, i, block_height, undo)
@@ -652,7 +652,7 @@ class Storage(object):
         for i, x in reversed(list(enumerate(tx.get('inputs')))):
             addr = prev_addr[i]
             if addr is not None:
-                txi = (x.get('prevout_hash') + int_to_unsigned_long_bytes_hex(x.get('prevout_n'))).decode('hex')
+                txi = (x.get('prevout_hash') + int_to_hex4(x.get('prevout_n'))).decode('hex')
                 self.revert_set_spent(addr, txi, undo)
                 touched_addr.add(addr)
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -56,30 +56,27 @@ def header_to_string(res):
            + int_to_hex4(int(res.get('nonce')))
 
 
-def _bytes_unpacker_for_number_format(format):
-    unpack = struct.Struct(format).unpack
-
-    def unpack_and_normalize(s):
-        return unpack(s)[0]
-
-    return unpack_and_normalize
+_unpack_int_from_bytes4 = struct.Struct("<L").unpack
+_unpack_int_from_bytes8 = struct.Struct("<Q").unpack
 
 
-int_from_bytes4 = _bytes_unpacker_for_number_format("<L")
-int_from_bytes8 = _bytes_unpacker_for_number_format("<Q")
+def int_from_bytes4(s):
+    return _unpack_int_from_bytes4(s)[0]
 
 
-def _int_to_bytes_converters_for_number_format(format):
-    pack = struct.Struct(format).pack
-
-    def pack_and_convert_to_hex(i):
-        return pack(i).encode('hex')
-
-    return pack, pack_and_convert_to_hex
+def int_from_bytes8(s):
+    return _unpack_int_from_bytes8(s)[0]
 
 
-int_to_bytes4, int_to_hex4 = _int_to_bytes_converters_for_number_format('<L')
-int_to_bytes8, int_to_hex8 = _int_to_bytes_converters_for_number_format('<Q')
+int_to_bytes4 = struct.Struct('<L').pack
+int_to_bytes8 = struct.Struct('<Q').pack
+
+
+def int_to_hex4(i):
+    return int_to_bytes4(i).encode('hex')
+
+def int_to_hex8(i):
+    return int_to_bytes8(i).encode('hex')
 
 
 def header_from_string(s):

--- a/src/utils.py
+++ b/src/utils.py
@@ -48,12 +48,12 @@ def header_to_string(res):
     if pbh is None:
         pbh = '0'*64
 
-    return int_to_signed_long_bytes_hex(res.get('version')) \
-        + rev_hex(pbh) \
-        + rev_hex(res.get('merkle_root')) \
-        + int_to_unsigned_long_bytes_hex(int(res.get('timestamp'))) \
-        + int_to_unsigned_long_bytes_hex(int(res.get('bits'))) \
-        + int_to_unsigned_long_bytes_hex(int(res.get('nonce')))
+    return int_to_hex4(res.get('version')) \
+           + rev_hex(pbh) \
+           + rev_hex(res.get('merkle_root')) \
+           + int_to_hex4(int(res.get('timestamp'))) \
+           + int_to_hex4(int(res.get('bits'))) \
+           + int_to_hex4(int(res.get('nonce')))
 
 
 def _bytes_unpacker_for_number_format(format):
@@ -65,9 +65,8 @@ def _bytes_unpacker_for_number_format(format):
     return unpack_and_normalize
 
 
-signed_long_from_bytes = _bytes_unpacker_for_number_format("<l")
-unsigned_long_from_bytes = _bytes_unpacker_for_number_format("<L")
-unsigned_long_long_from_bytes = _bytes_unpacker_for_number_format("<Q")
+int_from_bytes4 = _bytes_unpacker_for_number_format("<L")
+int_from_bytes8 = _bytes_unpacker_for_number_format("<Q")
 
 
 def _int_to_bytes_converters_for_number_format(format):
@@ -79,19 +78,18 @@ def _int_to_bytes_converters_for_number_format(format):
     return pack, pack_and_convert_to_hex
 
 
-int_to_signed_long_bytes, int_to_signed_long_bytes_hex = _int_to_bytes_converters_for_number_format('<l')
-int_to_unsigned_long_bytes, int_to_unsigned_long_bytes_hex = _int_to_bytes_converters_for_number_format('<L')
-int_to_unsigned_long_long_bytes, int_to_unsigned_long_long_bytes_hex = _int_to_bytes_converters_for_number_format('<Q')
+int_to_bytes4, int_to_hex4 = _int_to_bytes_converters_for_number_format('<L')
+int_to_bytes8, int_to_hex8 = _int_to_bytes_converters_for_number_format('<Q')
 
 
 def header_from_string(s):
     return {
-        'version': signed_long_from_bytes(s[0:4]),
+        'version': int_from_bytes4(s[0:4]),
         'prev_block_hash': hash_encode(s[4:36]),
         'merkle_root': hash_encode(s[36:68]),
-        'timestamp': unsigned_long_from_bytes(s[68:72]),
-        'bits': unsigned_long_from_bytes(s[72:76]),
-        'nonce': unsigned_long_from_bytes(s[76:80]),
+        'timestamp': int_from_bytes4(s[68:72]),
+        'bits': int_from_bytes4(s[72:76]),
+        'nonce': int_from_bytes4(s[76:80]),
     }
 
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -56,16 +56,16 @@ def header_to_string(res):
            + int_to_hex4(int(res.get('nonce')))
 
 
-_unpack_int_from_bytes4 = struct.Struct("<L").unpack
-_unpack_int_from_bytes8 = struct.Struct("<Q").unpack
+_unpack_bytes4_to_int = struct.Struct("<L").unpack
+_unpack_bytes8_to_int = struct.Struct("<Q").unpack
 
 
-def int_from_bytes4(s):
-    return _unpack_int_from_bytes4(s)[0]
+def bytes4_to_int(s):
+    return _unpack_bytes4_to_int(s)[0]
 
 
-def int_from_bytes8(s):
-    return _unpack_int_from_bytes8(s)[0]
+def bytes8_to_int(s):
+    return _unpack_bytes8_to_int(s)[0]
 
 
 int_to_bytes4 = struct.Struct('<L').pack
@@ -75,18 +75,19 @@ int_to_bytes8 = struct.Struct('<Q').pack
 def int_to_hex4(i):
     return int_to_bytes4(i).encode('hex')
 
+
 def int_to_hex8(i):
     return int_to_bytes8(i).encode('hex')
 
 
 def header_from_string(s):
     return {
-        'version': int_from_bytes4(s[0:4]),
+        'version': bytes4_to_int(s[0:4]),
         'prev_block_hash': hash_encode(s[4:36]),
         'merkle_root': hash_encode(s[36:68]),
-        'timestamp': int_from_bytes4(s[68:72]),
-        'bits': int_from_bytes4(s[72:76]),
-        'nonce': int_from_bytes4(s[76:80]),
+        'timestamp': bytes4_to_int(s[68:72]),
+        'bits': bytes4_to_int(s[72:76]),
+        'nonce': bytes4_to_int(s[76:80]),
     }
 
 


### PR DESCRIPTION
The biggest optimization this offers is replacing the integer/hex string/bytes conversion functions that are called thousands of times for every block. The new versions of those functions are a bit closer to the machine layer in implementation. This also has the trivial optimization of replacing `pop`s with `del`s where a return value isn't used.

Tested on OS X, Python 2.7.11 w/ Electrum 2.5.4 wallet.