### PR TITLE
make sure ZeroDivisionError never happens

### DIFF
--- a/src/blockchain_processor.py
+++ b/src/blockchain_processor.py
@@ -119,7 +119,7 @@ class BlockchainProcessor(Processor):
         self.time_ref = time.time()
 
     def print_time(self, num_tx):
-        delta = time.time() - self.time_ref
+        delta = time.time() - self.time_ref + 0000000000.000001
         # leaky averages
         seconds_per_block, tx_per_second, n = self.avg_time
         alpha = (1. + 0.01 * n)/(n+1)


### PR DESCRIPTION
When trying to get my electrum server synced and build the entire chain it kept stopping with this error:

Exception in thread Thread-4:
Traceback (most recent call last):
File "/usr/lib/python2.7/threading.py", line 801, in __bootstrap_inner
self.run()
File "/usr/lib/python2.7/threading.py", line 754, in run
self.__target(self.__args, *self.__kwargs)
File "/usr/lib/python2.7/site-packages/electrumserver/blockchain_processor.py", line 104, in do_catch_up
self.catch_up(sync=False)
File "/usr/lib/python2.7/site-packages/electrumserver/blockchain_processor.py", line 709, in catch_up
self.print_time(n)
File "/usr/lib/python2.7/site-packages/electrumserver/blockchain_processor.py", line 128, in print_time
tx_per_second = (1-alpha2) * tx_per_second + alpha2 * num_tx / delta
ZeroDivisionError: float division by zero

^CINFO:electrum:Stopping Stratum
