### PR TITLE
configure: add `set -e` at the top

### DIFF
--- a/configure
+++ b/configure
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # check root
 if [ ! "$(id -u)" == "0" ]; then


### PR DESCRIPTION
Add `set -e` at the top so the script stops being
processed when any of the commands fail.