### PR TITLE
Populate version from current git commit hash

### DIFF
--- a/electrum-server
+++ b/electrum-server
@@ -86,7 +86,7 @@ case "$1" in
 	    echo "Server running (pid $PID)"
 	fi
 	;;
-    getinfo|peers|numpeers|sessions|numsessions)
+    getinfo|peers|numpeers|sessions|numsessions|version)
 	if [ ! "$PID" ]; then
 	    echo "Server not running"
 	    exit
@@ -103,7 +103,7 @@ case "$1" in
 	$0 start
 	;;
     *)
-	echo "Usage: electrum-server {start|stop|restart|status|getinfo|peers|numpeers|sessions|numsessions}"
+	echo "Usage: electrum-server {start|stop|restart|status|getinfo|peers|numpeers|sessions|numsessions|version}"
 	exit 1
 	;;
 esac

--- a/run_electrum_server.py
+++ b/run_electrum_server.py
@@ -184,6 +184,10 @@ def cmd_peers():
 def cmd_numpeers():
     return len(server_proc.peers)
 
+def cmd_version():
+    from electrumserver import version
+    return version.VERSION
+
 
 hp = None
 def cmd_guppy():
@@ -317,6 +321,7 @@ if __name__ == '__main__':
     server.register_function(cmd_debug, 'debug')
     server.register_function(cmd_guppy, 'guppy')
     server.register_function(cmd_banner_update, 'banner_update')
+    server.register_function(cmd_version, 'version')
     server.socket.settimeout(1)
  
     while not shared.stopped():

--- a/setup.py
+++ b/setup.py
@@ -1,30 +1,43 @@
 from setuptools import setup
+from src import version
+import shutil
 
-setup(
-    name="electrum-server",
-    version="1.0",
-    scripts=['run_electrum_server.py','electrum-server'],
-    install_requires=['plyvel','jsonrpclib', 'irc >= 11, <=14.0'],
-    package_dir={
-        'electrumserver':'src'
+# Keep a copy of the current version.py to restore it after installation.
+shutil.copyfile('src/version.py', 'src/version.py.bak')
+# Overwrite the version file before it's installed (and unable to read the repository).
+with open('src/version.py','w') as f:
+    f.write('VERSION="{}"\nPROTOCOL_VERSION="{}"\n'.format(version.VERSION, version.PROTOCOL_VERSION))
+
+
+try:
+    setup(
+        name="electrum-server",
+        version="1.0",
+        scripts=['run_electrum_server.py','electrum-server'],
+        install_requires=['plyvel','jsonrpclib', 'irc >= 11, <=14.0'],
+        package_dir={
+            'electrumserver':'src'
         },
-    py_modules=[
-        'electrumserver.__init__',
-        'electrumserver.utils',
-        'electrumserver.storage',
-        'electrumserver.deserialize',
-        'electrumserver.networks',
-        'electrumserver.blockchain_processor',
-        'electrumserver.server_processor',
-        'electrumserver.processor',
-        'electrumserver.version',
-        'electrumserver.ircthread',
-        'electrumserver.stratum_tcp'
-    ],
-    description="Bitcoin Electrum Server",
-    author="Thomas Voegtlin",
-    author_email="thomasv@electrum.org",
-    license="MIT Licence",
-    url="https://github.com/spesmilo/electrum-server/",
-    long_description="""Server for the Electrum Lightweight Bitcoin Wallet"""
-)
+        py_modules=[
+            'electrumserver.__init__',
+            'electrumserver.utils',
+            'electrumserver.storage',
+            'electrumserver.deserialize',
+            'electrumserver.networks',
+            'electrumserver.blockchain_processor',
+            'electrumserver.server_processor',
+            'electrumserver.processor',
+            'electrumserver.version',
+            'electrumserver.ircthread',
+            'electrumserver.stratum_tcp'
+        ],
+        description="Bitcoin Electrum Server",
+        author="Thomas Voegtlin",
+        author_email="thomasv@electrum.org",
+        license="MIT Licence",
+        url="https://github.com/spesmilo/electrum-server/",
+        long_description="""Server for the Electrum Lightweight Bitcoin Wallet"""
+    )
+finally:
+    # Always restore version.py
+    shutil.move('src/version.py.bak', 'src/version.py')

--- a/src/ircthread.py
+++ b/src/ircthread.py
@@ -30,7 +30,7 @@ import Queue
 import irc.client
 from utils import logger
 from utils import Hash
-from version import VERSION
+from version import PROTOCOL_VERSION
 
 out_msg = []
 
@@ -64,7 +64,7 @@ class IrcThread(threading.Thread):
         self.who_queue = Queue.Queue()
 
     def getname(self):
-        s = 'v' + VERSION + ' '
+        s = 'v' + PROTOCOL_VERSION + ' '
         if self.pruning:
             s += 'p' + self.pruning_limit + ' '
 

--- a/src/version.py
+++ b/src/version.py
@@ -1,1 +1,7 @@
-VERSION = "1.0"
+PROTOCOL_VERSION = 1
+
+def _get_commit_hash():
+    import subprocess
+    return subprocess.check_output(["git", "show-ref", "HEAD", "-s", "--abbrev"]).strip()
+
+VERSION = _get_commit_hash()


### PR DESCRIPTION
This combines the convenience of not having to manually bump
version numbers with the ability to find out if a specific server
provides a specific feature or uses a specific bugfix.

This also adds an `electrum-server version` command to check the
currently running version.

This doesn't set the SHA-hash as a version for the installation process
because setuptools/distutils requires an incrementing version format.

The protocol version was moved to a different variable that is only used
in IRC peer discovery.