### PR TITLE
Add the TXO's value to the response from get_mempool since we have it

### DIFF
--- a/src/blockchain_processor.py
+++ b/src/blockchain_processor.py
@@ -304,7 +304,7 @@ class BlockchainProcessor(Processor):
             for tx_hash, delta in self.mempool_hist.get(addr, ()):
                 height = -1 if self.mempool_unconfirmed.get(tx_hash) else 0
                 fee = self.mempool_fees.get(tx_hash)
-                hist.append({'tx_hash':tx_hash, 'height':height, 'fee':fee})
+                hist.append({'tx_hash':tx_hash, 'height':height, 'fee':fee, 'value':delta})
         return hist
 
     def get_history(self, addr, cache_only=False):


### PR DESCRIPTION
The response from API call `blockchain.address.get_mempool` lists the transaction hashes but did not include the TXO amount, even though _it's right there already_ (as 'delta').

This is a simple one-line change, which adds the additional data to the response, using the field name `value` to align with other responses.

Unfortunately, I don't have the means to test this change, and a number of API responses will be affected because they call `get_unconfirmed_history()` indirectly. Hopefully clients are going to ignore new JSON fields.