### PR TITLE
HOWTO.md: fix configure invocation

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -152,7 +152,7 @@ We will download the latest git snapshot for Electrum to configure and install i
     $ git clone https://github.com/spesmilo/electrum-server.git
     $ cd electrum-server
     $ sudo apt-get install python-setuptools
-    $ sudo configure
+    $ sudo ./configure
     $ sudo python setup.py install
 
 See the INSTALL file for more information about the configure and install commands.


### PR DESCRIPTION
Simply doing `sudo configure` would yield:

sudo: configure: command not found

At least in my ubuntu 16.04 server one needs
to specify the current dir (./).