### PR TITLE
added a reorg_limit option to handle deep reorgs in the bitcoin testnet

### DIFF
--- a/run_electrum_server.py
+++ b/run_electrum_server.py
@@ -105,6 +105,7 @@ def create_config(filename=None):
     config.add_section('leveldb')
     config.set('leveldb', 'path', '/dev/shm/electrum_db')
     config.set('leveldb', 'pruning_limit', '100')
+    config.set('leveldb', 'reorg_limit', '100')
     config.set('leveldb', 'utxo_cache', str(64*1024*1024))
     config.set('leveldb', 'hist_cache', str(128*1024*1024))
     config.set('leveldb', 'addr_cache', str(16*1024*1024))


### PR DESCRIPTION
This patch makes the reorg limit configurable to better handle the bitcoin testnet. Without this patch it will stuck on >100 block reorgs and the database must be reconstructed.

The reorg_limit value can be changed in the config file under the [leveldb] section. The default value is set to 100 for backwards compatibility and it set in the `undo` database under the `reorg_limit` key. It cannot change after that.