### PR TITLE
Add banner_update cmd to electrum-server

### DIFF
--- a/electrum-server
+++ b/electrum-server
@@ -86,7 +86,7 @@ case "$1" in
 	    echo "Server running (pid $PID)"
 	fi
 	;;
-    getinfo|peers|numpeers|sessions|numsessions)
+    getinfo|peers|numpeers|sessions|numsessions|banner_update)
 	if [ ! "$PID" ]; then
 	    echo "Server not running"
 	    exit
@@ -103,7 +103,7 @@ case "$1" in
 	$0 start
 	;;
     *)
-	echo "Usage: electrum-server {start|stop|restart|status|getinfo|peers|numpeers|sessions|numsessions}"
+	echo "Usage: electrum-server {start|stop|restart|status|getinfo|peers|numpeers|sessions|numsessions|banner_update}"
 	exit 1
 	;;
 esac


### PR DESCRIPTION
`cmd_banner_update` already exists in `run_electrum_server.py`, but can't be called via the `electrum-server` script.

Adding this allows dynamically updating the banner through the familiar `electrum-server` interface without a full restart, which would cause a reconnection to IRC and downtime of ~5m.

Interesting ways to use a periodically updated banner:
- server uptime
- # relayed txs
- auto-update bitcoin/electrum-server version
- auto-update fee estimates and donation address