### PR TITLE
In electrum-server, ensure typical bin directories are on $PATH.

### DIFF
--- a/electrum-server
+++ b/electrum-server
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-
+PATH=$PATH:/sbin:/usr/sbin:/bin:/usr/bin:/usr/local/bin
 electrum_config="/etc/electrum.conf"
 if [ ! -f $electrum_config ]; then
     echo "$electrum_config does not exist"


### PR DESCRIPTION
When running an init script at boot, the $PATH variable may not include some typical directories like /usr/local/bin. This change ensures those directories are on the path, so that bash can find run_electrum_server.py if it is /usr/local/bin or one of the other typical bin directories.